### PR TITLE
Remove Oracle Cloud Infrastructure File Storage

### DIFF
--- a/data/Services.json
+++ b/data/Services.json
@@ -909,11 +909,6 @@
 			"ref": "https://cloud.ibm.com/docs/infrastructure/FileStorage?topic=FileStorage-about#getting-started-with-file-storage",
 			"icon": "ibmcloud.png"
 		}],
-		"oracle": [{
-			"name": "Oracle Cloud Infrastructure File Storage",
-			"ref": "https://www.oracle.com/cloud/storage/file-storage.html",
-			"icon": "storage.png"
-		}],
 		"alibaba": [{
 			"name": "NAS File Storage",
 			"ref": "https://www.alibabacloud.com/product/nas",


### PR DESCRIPTION
Remove Oracle Cloud Infrastructure File Storage because it uses Network File System version 3.0 (NFSv3) and it is not compatible with Server Message Block (SMB) or NFSv4.

See doc: https://docs.oracle.com/en/solutions/learn-storage-options-cloud/design-learn-shared-storage-options-oracle-cloud-infrastructure.html#GUID-2E07B558-27CA-41B5-A142-D159560A82A4